### PR TITLE
Firmware ledger 1.5.5

### DIFF
--- a/app/src/menu.js
+++ b/app/src/menu.js
@@ -135,10 +135,6 @@ const menu = {
             label: i18n.t('Check your GDT Membership'),
             click: menu.onClickLink.bind(null, electron, 'https://check.liskgdt.net/'),
           },
-          {
-            label: i18n.t('Vote for me and ask a fee refund!'),
-            click: menu.onClickLink.bind(null, electron, 'https://refund.liskgdt.net/'),
-          },
         ],
       },
       {

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -248,7 +248,6 @@
   "Version": "Version",
   "View": "View",
   "Vote for delegates": "Vote for delegates",
-  "Vote for me and ask a fee refund!": "Vote for me and ask a fee refund!",
   "Vote_noun": "Vote",
   "Vote_verb": "Vote",
   "Votes": "Votes",

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -244,7 +244,7 @@
   "Use empty passphrase to access your original account.": "Use empty passphrase to access your original account.",
   "Username": "Username",
   "Verify message": "Verify message",
-  "Verify the address on your Device!": "Verify the address on your Device!",
+  "Verify the address on your device!": "Verify the address on your device!",
   "Version": "Version",
   "View": "View",
   "Vote for delegates": "Vote for delegates",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liskish-wallet",
-  "version": "2.0.1-trezor-rc.2",
+  "version": "2.0.2-beta-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2589,8 +2589,7 @@
     "base64-js": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
-      "dev": true
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
     },
     "base64id": {
       "version": "1.0.0",
@@ -3239,6 +3238,15 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -4600,9 +4608,12 @@
       }
     },
     "crc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
-      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      }
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -5568,9 +5579,9 @@
       "dev": true
     },
     "dpos-ledger-api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dpos-ledger-api/-/dpos-ledger-api-1.1.0.tgz",
-      "integrity": "sha512-CzYwl/DG41kTIiCGbaMbxpIp50V6R/Di96lZ4IilEVfEQK4yCGbhKHeNW7dCwa2/Qd3C4pvqkMNDmiYm5Wew1w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dpos-ledger-api/-/dpos-ledger-api-2.0.0.tgz",
+      "integrity": "sha512-WQ3TuemxfHdgsn+YgH39CosCnB5FpF31UiiEQpYKbtczsoJPWruaxTO3l+cfk8eyOB+rYkabQr40rooDkTTacQ==",
       "requires": {
         "bip32-path": "^0.4.2",
         "crc": "^3.5.0"
@@ -10289,8 +10300,7 @@
     "ieee754": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
-      "dev": true
+      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
     },
     "ignore": {
       "version": "3.3.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "bitcore-mnemonic": "1.2.5",
     "browser-or-node": "1.0.2",
     "copy-to-clipboard": "3.0.8",
-    "dpos-ledger-api": "1.1.0",
+    "dpos-ledger-api": "2.0.0",
     "electron-localshortcut": "^2.0.2",
     "flexboxgrid": "=6.3.1",
     "history": "=4.7.2",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "url": "https://github.com/hirishh/liskish-wallet"
   },
   "dependencies": {
-    "@ledgerhq/hw-transport-node-hid": "^4.22.0",
-    "@ledgerhq/hw-transport-u2f": "^4.21.0",
+    "@ledgerhq/hw-transport-node-hid": "^4.33.3",
+    "@ledgerhq/hw-transport-u2f": "^4.32.0",
     "babel-polyfill": "6.26.0",
     "bignumber.js": "4.0.4",
     "bitcore-mnemonic": "1.2.5",

--- a/src/utils/rawTransactionWrapper.js
+++ b/src/utils/rawTransactionWrapper.js
@@ -8,7 +8,10 @@ import transactionTypes from '../constants/transactionTypes';
 
 const bufferOffsetTimestamp = 10;
 
-const createAsset = data => ((data && data.length > 0) ? { data } : {});
+const createSendAsset = data => ((data && data.length > 0) ? { data } : {});
+
+// eslint-disable-next-line max-len
+export const getTransactionBytes = transaction => Lisk.transaction.utils.getTransactionBytes(transaction);
 
 export const createSendTX = (senderPublicKey, recipientId, amount, data = null) => {
   const transaction = {
@@ -18,7 +21,7 @@ export const createSendTX = (senderPublicKey, recipientId, amount, data = null) 
     senderPublicKey,
     recipientId,
     timestamp: Lisk.transaction.utils.getTimeFromBlockchainEpoch() - bufferOffsetTimestamp,
-    asset: createAsset(data),
+    asset: createSendAsset(data),
   };
   return transaction;
 };
@@ -57,7 +60,7 @@ export const createSecondPassphraseTX = (senderPublicKey, secondPublicKey) => {
   return transaction;
 };
 
-export const concatVoteLists =
+const concatVoteLists =
   (voteList, unvoteList) =>
     voteList.map(delegate => `+${delegate}`).concat(unvoteList.map(delegate => `-${delegate}`));
 


### PR DESCRIPTION
### What was the problem?

Ledger Firmware 1.5.5 introduces new non-backward compatible changes in the Bip32-ed25519 derivation path feature. This PR is to address it and manage the derivation path correctly.

### How did I fix it?

Updating to ledger-dpos-api:2.0.0
